### PR TITLE
Revert "Bump aquasecurity/trivy-action from 0.13.1 to 0.14.0"

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Trivy scan'
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.13.1
         id: trivy-fs
         with:
           scan-type: 'fs'


### PR DESCRIPTION
Reverts nothub/headlessmc-docker#5